### PR TITLE
Improved functionalities of Engine

### DIFF
--- a/Creyon/src/Render/CreyonWindow.cpp
+++ b/Creyon/src/Render/CreyonWindow.cpp
@@ -79,7 +79,7 @@ namespace Creyon {
 
 	float CreyonWindow::deltaTime() {
 		//Calculating time taken to render previous frame
-		float current = CreyonWindow::getTime();
+		float current = getTime();
 		float delta = current - m_lastFrame;
 		//updates lastFrame value
 		m_lastFrame = current;

--- a/Creyon/src/Render/CreyonWindow.h
+++ b/Creyon/src/Render/CreyonWindow.h
@@ -91,11 +91,11 @@ namespace Creyon {
 			return glfwWindowShouldClose(mp_window);
 		}
 
-		//Returns elapsed Time from glfw initialisation
-		static float getTime() {
-			return (float)glfwGetTime();
-		}
-
 	};
+
+	//Returns elapsed Time from glfw initialisation
+	inline float getTime() {
+		return (float)glfwGetTime();
+	}
 
 }

--- a/Creyon/src/Render/Shaderprogram.cpp
+++ b/Creyon/src/Render/Shaderprogram.cpp
@@ -66,4 +66,16 @@ namespace Creyon {
 			std::cout << "\nError: Shader Program linking failed!\n" << infolog << "\n";
 		}
 	}
+
+	GLint Shaderprogram::locateUniform(const std::string &uniformName) {
+		return glGetUniformLocation(programId, uniformName.c_str());
+	}
+
+	void Shaderprogram::setInt(const std::string& uniformName, int value) {
+		glUniform1i(locateUniform(uniformName), value);
+	}
+
+	void Shaderprogram::setFloat(const std::string& uniformName, float value) {
+		glUniform1f(locateUniform(uniformName), value);
+	}
 }

--- a/Creyon/src/Render/Shaderprogram.h
+++ b/Creyon/src/Render/Shaderprogram.h
@@ -22,6 +22,11 @@ namespace Creyon {
 		inline unsigned int getId() {
 			return programId;
 		}
+
+		//Use the Shader Program
+		inline void useProgram() {
+			glUseProgram(programId);
+		}
 		
 		// Add a Shader to program object
 		void addShader(const char* pathtoShader,GLenum Shadertype);
@@ -29,10 +34,14 @@ namespace Creyon {
 		//Link the Shaderprogram
 		void link();
 
-		//Use the Shader Program
-		inline void useProgram() {
-			glUseProgram(programId);
-		}
+		//Returns the Uniform's location
+		GLint locateUniform(const std::string &uniformName);
+
+		//Locates and sets int value to a uniform
+		void setInt(const std::string& uniformName, int value);
+
+		//Locates and sets float value to a uniform
+		void setFloat(const std::string& uniformName, float value);
 	};
 }
 

--- a/Creyon/src/Render/VertexBuffer.cpp
+++ b/Creyon/src/Render/VertexBuffer.cpp
@@ -24,7 +24,7 @@ namespace Creyon {
 
 	void setVertexAttribPtr(GLuint locationIndex, GLint size, GLboolean normalized, int stride, int offset) {
 		//Sets location index, stride and offset of data
-		glVertexAttribPointer(locationIndex, size, GL_FLOAT, GL_FALSE, stride * sizeof(float), 
+		glVertexAttribPointer(locationIndex, size, GL_FLOAT, normalized, stride * sizeof(float), 
 							 (void*)(offset * sizeof(float)) );
 
 		//Enables Vertex Attribute

--- a/Sandbox/src/EngineApp.cpp
+++ b/Sandbox/src/EngineApp.cpp
@@ -136,12 +136,12 @@ namespace Creyon {
 			tex2.setTexUnit(GL_TEXTURE1);
 
 			programrect.useProgram();
-			glUniform1i(glGetUniformLocation(programrect.getId(), "ourTexture"), 0);
-			glUniform1i(glGetUniformLocation(programrect.getId(), "ourTexture2"), 1);
-
-			unsigned int modelId = glGetUniformLocation(programrect.getId(), "model");
-			unsigned int viewId = glGetUniformLocation(programrect.getId(), "view");
-			unsigned int projId = glGetUniformLocation(programrect.getId(), "projection");
+			programrect.setInt("ourTexture", 0);
+			programrect.setInt("ourTexture2", 1);
+			
+			unsigned int modelId = programrect.locateUniform("model");
+			unsigned int viewId = programrect.locateUniform("view");	
+			unsigned int projId = programrect.locateUniform("projection");
 			
 			vao.bind();
 			
@@ -149,7 +149,7 @@ namespace Creyon {
 			glUniformMatrix4fv(viewId, 1, GL_TRUE, view.m_elems);
 
 			for(unsigned int i=0 ; i<10; ++i){
-				mat44 model = rotateY(CreyonWindow::getTime()*(i+1), false) * translate(positions[i]);
+				mat44 model = rotateY(getTime()*(i+1), false) * translate(positions[i]);
 				mat44 proj = persp(800.0f / 600.0f, pi_u4, 100.0f, 0.1f);
 				glUniformMatrix4fv(modelId, 1, GL_TRUE, model.m_elems);
 				glUniformMatrix4fv(projId, 1, GL_TRUE, proj.m_elems);


### PR DESCRIPTION
- getTime() is now non-member function as it does not belong to CreyonWindow class
- Added locateUniform and setInt, setFloat functions to easily access and set shader uniforms
- fixed setVertexAttribPtr() to use the parameter "normalized" value provided by user which was earlier not used and always set to GL_FALSE